### PR TITLE
Сериализация указателей

### DIFF
--- a/interfaces/XmlDocNode.h
+++ b/interfaces/XmlDocNode.h
@@ -24,4 +24,6 @@ public:
 
 	virtual void set_value(std::string const &value) = 0;
 	virtual std::string get_value() const = 0;
+
+	virtual std::string get_attribute_value(std::string const &attribute_name) const = 0;
 };

--- a/interfaces/impl/PugiXmlDoc.cpp
+++ b/interfaces/impl/PugiXmlDoc.cpp
@@ -54,3 +54,8 @@ std::string PugiXmlDoc::get_value() const
 {
 	return PugiXmlDocNode(m_doc).get_value();
 }
+
+std::string PugiXmlDoc::get_attribute_value(std::string const &attribute_name) const
+{
+	return PugiXmlDocNode(m_doc).get_attribute_value(attribute_name);
+}

--- a/interfaces/impl/PugiXmlDoc.h
+++ b/interfaces/impl/PugiXmlDoc.h
@@ -20,6 +20,8 @@ public:
 	void set_value(std::string const &value) override;
 	std::string get_value() const override;
 
+	std::string get_attribute_value(std::string const &attribute_name) const override;
+
 private:
 	pugi::xml_document m_doc;
 };

--- a/interfaces/impl/PugiXmlDocNode.cpp
+++ b/interfaces/impl/PugiXmlDocNode.cpp
@@ -64,3 +64,9 @@ std::string PugiXmlDocNode::get_value() const
 {
 	return m_node.child_value();
 }
+
+std::string PugiXmlDocNode::get_attribute_value(std::string const &attr_name) const
+{
+	auto attr = m_node.find_attribute([&attr_name](auto const &attr){ return std::string(attr.name()) == attr_name; });
+	return attr ? attr.value() : "";
+}

--- a/interfaces/impl/PugiXmlDocNode.h
+++ b/interfaces/impl/PugiXmlDocNode.h
@@ -21,6 +21,8 @@ public:
 	void set_value(std::string const &value) override;
 	std::string get_value() const override;
 
+	std::string get_attribute_value(std::string const &attribute_name) const override;
+
 private:
 	pugi::xml_node m_node;
 };

--- a/io/IOTypes.h
+++ b/io/IOTypes.h
@@ -31,6 +31,23 @@ namespace io
 	};
 
 	template<typename T>
+	struct PointerInput
+	{
+		std::string name;
+		ptr_t<T> const &ptr;
+	};
+
+	template<typename T, typename CreateFunc>
+	struct PointerOutput
+	{
+		std::string name;
+		ptr_t<T> &ptr;
+		CreateFunc create_func;
+	};
+
+	// TODO: убрать или перенести хелперные методы.
+
+	template<typename T>
 	auto constant(char const *name, T const &value)
 	{
 		return io::Constant<T>{name, value};
@@ -53,11 +70,25 @@ namespace io
 	{
 		return io::ReferenceOutput<BaseObjId>{base_obj_id, ref_name};
 	}
+	template<typename T>
+	auto pointer_input(char const *ptr_name, ptr_t<T> const &ptr)
+	{
+		return io::PointerInput<T>{ptr_name, ptr};
+	}
+
+	template<typename T, typename CreateFunc>
+	auto pointer_output(char const *ptr_name, ptr_t<T> &ptr, CreateFunc create_func)
+	{
+		return io::PointerOutput<T, CreateFunc>{ptr_name, ptr, create_func};
+	}
 
 	#define IO_CONSTANT(c) io::constant(#c, c)
 	#define IO_VARIABLE(v) io::variable(#v, v)
 
 	#define IO_REFERENCE_INPUT(ref, base_obj_id) io::reference_input(ref, #ref, base_obj_id)
 	#define IO_REFERENCE_OUTPUT(base_obj_id, ref_name) io::reference_output(base_obj_id, ref_name)
+
+	#define IO_POINTER_INPUT(ptr) io::pointer_input(#ptr, ptr)
+	#define IO_POINTER_OUTPUT(ptr, create_func) io::pointer_output(#ptr, ptr, create_func)
 
 } // namespace io

--- a/io/XmlIOStream.h
+++ b/io/XmlIOStream.h
@@ -19,12 +19,25 @@ namespace io
 		XmlIOStream& operator<<(ReferenceInput<T, BaseObjId> const &r);
 
 		template<typename T>
+		XmlIOStream& operator<<(PointerInput<T> const &p);
+
+		template<typename T>
 		XmlIOStream const& operator>>(Variable<T> const &v) const;
 
 		template<typename BaseObjId>
 		XmlIOStream const& operator>>(ReferenceOutput<BaseObjId> const &r) const;
 
+		template<typename T, typename CreateFunc>
+		XmlIOStream const& operator>>(PointerOutput<T, CreateFunc> const &p) const;
+
 	private:
+		template<typename T>
+		static auto get_ptr_name()
+		{
+			std::string ptr_name(io::trait_functions<T>::name());
+			return ptr_name.append("_ptr");
+		}
+
 		XmlDocNodePtr m_node;
 	};
 
@@ -54,6 +67,22 @@ namespace io
 	}
 
 	template<typename T>
+	XmlIOStream& XmlIOStream::operator<<(PointerInput<T> const &p)
+	{
+		if (auto ptr_node = m_node->add_child(get_ptr_name<T>(),
+											  {{xml::attributes::var_name, p.name},
+												{xml::attributes::ptr_id, PointerTable<T>::get_pointer_id(p.ptr)}}))
+		{
+			if (p.ptr)
+			{
+				io::trait_functions<T>::serialize(*(p.ptr), ptr_node);
+			}
+		}
+
+		return *this;
+	}
+
+	template<typename T>
 	XmlIOStream const& XmlIOStream::operator>>(Variable<T> const &v) const
 	{
 		if (auto child_node = m_node->find_child(io::trait_functions<T>::name(), {xml::attributes::var_name, v.name}))
@@ -72,6 +101,24 @@ namespace io
 			if (auto base_obj_id_node = ref_node->find_child(io::trait_functions<BaseObjId>::name()))
 			{
 				io::trait_functions<BaseObjId>::unserialize(r.base_obj_id, base_obj_id_node);
+			}
+		}
+
+		return *this;
+	}
+
+	template<typename T, typename CreateFunc>
+	XmlIOStream const& XmlIOStream::operator>>(PointerOutput<T, CreateFunc> const &p) const
+	{
+		if (auto ptr_node = m_node->find_child(get_ptr_name<T>(), {xml::attributes::var_name, p.name}))
+		{
+			auto const id = ptr_node->get_attribute_value(xml::attributes::ptr_id);
+
+			p.ptr = PointerTable<T>::get_pointer_by_id(id, p.create_func);
+
+			if (p.ptr)
+			{
+				io::trait_functions<T>::unserialize(*(p.ptr), ptr_node);
 			}
 		}
 

--- a/io/XmlIOStream.h
+++ b/io/XmlIOStream.h
@@ -3,6 +3,7 @@
 #include "io/IOTraitFunctions.h"
 #include "interfaces/XmlDocNode.h"
 #include "xml/XmlAttributes.h"
+#include "utils/PointerTable.h"
 
 namespace io
 {

--- a/main/factory.h
+++ b/main/factory.h
@@ -1,0 +1,20 @@
+﻿#pragma once
+
+// [23.03.2020] NOTE: для корректной работы с сериализацией указателей
+// необходимо работать с типами/фабричным методом, представленными ниже.
+
+template<typename T>
+using ptr_t = std::shared_ptr<T>;
+
+template<typename T>
+using wptr_t = std::weak_ptr<T>;
+
+namespace factory
+{
+	template<typename T, typename... Args>
+	auto create(Args&&... args)
+	{
+		return std::make_shared<T>(std::forward<Args>(args)...);
+	}
+
+} // namespace factory

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -5,6 +5,7 @@ int main()
 {
 	serialization_tests::ints::structs_with_ints();
 	serialization_tests::ints::nested_int_structs();
+	serialization_tests::ints::int_pointers();
 
 	serialization_tests::arithmetic::struct_with_arithmetic_types();
 

--- a/main/pch.h
+++ b/main/pch.h
@@ -3,13 +3,17 @@
 #include <string>
 #include <array>
 #include <vector>
+#include <map>
 
 #include <algorithm>
 #include <memory>
 
 #include <type_traits>
 
+#include <sstream>
+
 #include <cassert>
 #include <cmath>
 
 #include "main/global.h"
+#include "main/factory.h"

--- a/tests/IntsTests.cpp
+++ b/tests/IntsTests.cpp
@@ -48,6 +48,31 @@ namespace serialization_tests
 			assert((loaded->val == init_val) && (*(loaded->ptr) == init_ptr) && (loaded->ref == init_ref));
 		}
 
+		void int_pointers()
+		{
+			int constexpr init_value1 = 193;
+			int constexpr init_value2 = 0;
+
+			std::string const filename("results/int_pointers.xml");
+
+			test::PointersToInts saved{};
+
+			saved.p1 = factory::create<int>(init_value1);
+			saved.p2 = factory::create<int>(init_value2);
+			saved.p3 = saved.p1;
+			saved.p4 = nullptr;
+
+			test_common_helpers::serialize(saved, filename);
+
+			test::PointersToInts loaded{};
+			loaded.unserialize(xml::Doc::make_by_file(filename));
+
+			assert(loaded.p1 && *(loaded.p1) == init_value1);
+			assert(loaded.p2 && *(loaded.p2) == init_value2);
+			assert(loaded.p3 == loaded.p1);
+			assert(loaded.p4 == nullptr);
+		}
+
 	} // namespace ints
 
 } // namespace serialization_tests

--- a/tests/SerializationTests.h
+++ b/tests/SerializationTests.h
@@ -7,6 +7,7 @@ namespace serialization_tests
 	{
 		void structs_with_ints();
 		void nested_int_structs();
+		void int_pointers();
 
 	} // namespace ints
 

--- a/tests/classes/Ints.cpp
+++ b/tests/classes/Ints.cpp
@@ -37,6 +37,11 @@ namespace
 		return test::Ints::unserialize(child);
 	}
 
+	auto create_int_ptr()
+	{
+		return factory::create<int>();
+	}
+
 } // namespace
 
 namespace test
@@ -148,6 +153,18 @@ namespace test
 		}
 
 		return nullptr;
+	}
+
+	void PointersToInts::serialize(XmlDocNodePtr const &node) const
+	{
+		io::XmlIOStream{node} << IO_POINTER_INPUT(p1) << IO_POINTER_INPUT(p2)
+			<< IO_POINTER_INPUT(p3) << IO_POINTER_INPUT(p4);
+	}
+
+	void PointersToInts::unserialize(XmlDocNodePtr const &node)
+	{
+		io::XmlIOStream{node} >> IO_POINTER_OUTPUT(p1, create_int_ptr) >> IO_POINTER_OUTPUT(p2, create_int_ptr)
+			>> IO_POINTER_OUTPUT(p3, create_int_ptr) >> IO_POINTER_OUTPUT(p4, create_int_ptr);
 	}
 
 } // namespace test

--- a/tests/classes/Ints.h
+++ b/tests/classes/Ints.h
@@ -54,4 +54,12 @@ namespace test
 		static std::unique_ptr<NestedInts> unserialize(XmlDocNodePtr const &node);
 	};
 
+	struct PointersToInts
+	{
+		ptr_t<int> p1{}, p2{}, p3{}, p4{};
+
+		void serialize(XmlDocNodePtr const &node) const;
+		void unserialize(XmlDocNodePtr const &node);
+	};
+
 } // namespace test

--- a/utils/PointerIdGenerator.h
+++ b/utils/PointerIdGenerator.h
@@ -1,0 +1,22 @@
+﻿#pragma once
+
+namespace
+{
+	using PointerId = std::string;
+
+	auto constexpr nullptr_id = "nullptr";
+
+	template<typename T>
+	PointerId generate_id(ptr_t<T> const &p)
+	{
+		if (!p)
+		{
+			return nullptr_id;
+		}
+
+		std::stringstream s;
+		s << std::addressof(*p);
+		return s.str();
+	}
+
+} // namespace

--- a/utils/PointerTable.h
+++ b/utils/PointerTable.h
@@ -1,0 +1,126 @@
+﻿#pragma once
+#include "utils/PointerIdGenerator.h"
+
+template<typename T>
+class PointerTable
+{
+public:
+	static PointerId get_pointer_id(ptr_t<T> const &ptr);
+
+	// Функция пытается найти в таблице указатель по id. Если указатель не найден,
+	// то с помощью create_func будет создан новый указатель, которому будет присвоен идентификатор id.
+	template<typename CreateFunc>
+	static ptr_t<T> get_pointer_by_id(PointerId const &id, CreateFunc create_func);
+
+private:
+	static PointerTable& get_table();
+
+	PointerTable() = default;
+
+	using Pointers = std::map<PointerId, wptr_t<T>>;
+	using PointersIterator = typename PointerTable<T>::Pointers::const_iterator;
+
+	PointersIterator find(ptr_t<T> const &ptr) const;
+	PointersIterator emplace(PointerId const &id, ptr_t<T> const &ptr);
+
+	void remove_expired_pointers();
+
+	Pointers m_pointers;
+};
+
+/**/
+
+template<typename T>
+PointerTable<T>& PointerTable<T>::get_table()
+{
+	static PointerTable<T> table;
+	table.remove_expired_pointers();
+	return table;
+}
+
+template<typename T>
+PointerId PointerTable<T>::get_pointer_id(ptr_t<T> const &ptr)
+{
+	if (!ptr)
+	{
+		return nullptr_id;
+	}
+
+	auto& table = get_table();
+
+	auto it = table.find(ptr);
+
+	if (it == table.m_pointers.cend())
+	{
+		it = table.emplace(generate_id(ptr), ptr);
+	}
+
+	return it->first;
+}
+
+template<typename T>
+template<typename CreateFunc>
+ptr_t<T> PointerTable<T>::get_pointer_by_id(PointerId const &id, CreateFunc create_func)
+{
+	if (id == nullptr_id)
+	{
+		return nullptr;
+	}
+
+	auto& table = get_table();
+
+	auto it = table.m_pointers.find(id);
+
+	ptr_t<T> ptr{};
+
+	if (it != table.m_pointers.cend())
+	{
+		ptr = it->second.lock();
+		assert(ptr);
+	}
+	else
+	{
+		ptr = create_func();
+		assert(ptr && L"Был создан нулевой указатель");
+
+		if (ptr)
+		{
+			table.emplace(id, ptr);
+		}
+	}
+
+	return ptr;
+}
+
+template<typename T>
+typename PointerTable<T>::PointersIterator PointerTable<T>::find(ptr_t<T> const &ptr) const
+{
+	assert(ptr && L"Ошибка: попытка найти нулевой указатель в таблице");
+
+	return std::find_if(m_pointers.cbegin(), m_pointers.cend(), [&ptr](auto const &pair)
+	{
+		auto ptr_in_table = pair.second;
+		assert(!ptr_in_table.expired() && L"Expired-указатели должны быть удалены при вызове get_table");
+		return ptr_in_table.lock() == ptr;
+	});
+}
+
+template<typename T>
+typename PointerTable<T>::PointersIterator PointerTable<T>::emplace(PointerId const &id, ptr_t<T> const &ptr)
+{
+	assert(ptr && L"Ошибка: попытка добавить нулевой указатель в таблицу");
+	assert((id != nullptr_id) && L"Ошибка: попытка присвоить nullptr_id ненулевому указателю");
+
+	auto pair = m_pointers.emplace(id, ptr);
+	assert(pair.second && L"Указатель не был добавлен в таблицу");
+	return pair.first;
+}
+
+template<typename T>
+void PointerTable<T>::remove_expired_pointers()
+{
+	for (auto it = m_pointers.begin(); it != m_pointers.end(); )
+	{
+		(it->second.expired()) ? it = m_pointers.erase(it) : ++it;
+	}
+}

--- a/utils/PointerTable.h
+++ b/utils/PointerTable.h
@@ -62,6 +62,12 @@ template<typename T>
 template<typename CreateFunc>
 ptr_t<T> PointerTable<T>::get_pointer_by_id(PointerId const &id, CreateFunc create_func)
 {
+	if (id.empty())
+	{
+		assert(false && L"Ошибка: попытка получить указатель по пустому id");
+		return nullptr;
+	}
+
 	if (id == nullptr_id)
 	{
 		return nullptr;

--- a/xml/XmlAttributes.h
+++ b/xml/XmlAttributes.h
@@ -6,6 +6,8 @@ namespace xml
 	{
 		auto constexpr var_name = "var_name";
 
+		auto constexpr ptr_id = "ptr_id";
+
 	} // namespace attributes
 
 } // namespace xml


### PR DESCRIPTION
**Работа с сериализацией указателей**

_Добавлено_: 
- Фабричный метод создания указателей
- Таблица указателей
- Тесты сериализации указателей на целые числа

Чтобы указатель мог работать с механизмами сериализации, его необходимо создавать с помощью _фабричного метода_, определенного в _main/factory.cpp_. При сериализации указатель применяется _таблица указателей_  (_utils/Pointerstable.h_): в ходе сериализации указатель получает уникальный идентификатор, в ходе десериализации указатель восстанавливается с помощью данного идентификатора.