### PR TITLE
Inheritance serialization

### DIFF
--- a/interfaces/XmlDocNode.h
+++ b/interfaces/XmlDocNode.h
@@ -25,5 +25,6 @@ public:
 	virtual void set_value(std::string const &value) = 0;
 	virtual std::string get_value() const = 0;
 
+	virtual void add_attributes(Attributes const &attributes) const = 0;
 	virtual std::string get_attribute_value(std::string const &attribute_name) const = 0;
 };

--- a/interfaces/impl/PugiXmlDoc.cpp
+++ b/interfaces/impl/PugiXmlDoc.cpp
@@ -55,6 +55,11 @@ std::string PugiXmlDoc::get_value() const
 	return PugiXmlDocNode(m_doc).get_value();
 }
 
+void PugiXmlDoc::add_attributes(Attributes const &attributes) const
+{
+	return PugiXmlDocNode(m_doc).add_attributes(attributes);
+}
+
 std::string PugiXmlDoc::get_attribute_value(std::string const &attribute_name) const
 {
 	return PugiXmlDocNode(m_doc).get_attribute_value(attribute_name);

--- a/interfaces/impl/PugiXmlDoc.h
+++ b/interfaces/impl/PugiXmlDoc.h
@@ -20,6 +20,7 @@ public:
 	void set_value(std::string const &value) override;
 	std::string get_value() const override;
 
+	void add_attributes(Attributes const &attributes) const;
 	std::string get_attribute_value(std::string const &attribute_name) const override;
 
 private:

--- a/interfaces/impl/PugiXmlDocNode.cpp
+++ b/interfaces/impl/PugiXmlDocNode.cpp
@@ -65,6 +65,11 @@ std::string PugiXmlDocNode::get_value() const
 	return m_node.child_value();
 }
 
+void PugiXmlDocNode::add_attributes(Attributes const &attributes) const
+{
+	append_attributes(m_node, attributes);
+}
+
 std::string PugiXmlDocNode::get_attribute_value(std::string const &attr_name) const
 {
 	auto attr = m_node.find_attribute([&attr_name](auto const &attr){ return std::string(attr.name()) == attr_name; });

--- a/interfaces/impl/PugiXmlDocNode.h
+++ b/interfaces/impl/PugiXmlDocNode.h
@@ -21,6 +21,7 @@ public:
 	void set_value(std::string const &value) override;
 	std::string get_value() const override;
 
+	void add_attributes(Attributes const &attributes) const;
 	std::string get_attribute_value(std::string const &attribute_name) const override;
 
 private:

--- a/io/IOTraitFunctions.cpp
+++ b/io/IOTraitFunctions.cpp
@@ -7,13 +7,25 @@ namespace test
 	{
 		class Base;
 	}
-}
+
+	namespace virtual_inheritance
+	{
+		struct B;
+	}
+
+} // namespace test
 
 namespace io
 {
-	template<> std::string get_class_name<test::multiple_inheritance::Base>() 
-	{ 
-		return AS_TEXT(multiple_inheritance::Base); 
+
+	template<> std::string get_class_name<test::virtual_inheritance::B>()
+	{
+		return AS_TEXT(virtual_inheritance::B);
+	}
+
+	template<> std::string get_class_name<test::multiple_inheritance::Base>()
+	{
+		return AS_TEXT(multiple_inheritance::Base);
 	}
 
 } // namespace io

--- a/io/IOTraitFunctions.cpp
+++ b/io/IOTraitFunctions.cpp
@@ -1,0 +1,19 @@
+﻿#include "main/pch.h"
+#include "io/IOTraitFunctions.h"
+
+namespace test
+{
+	namespace multiple_inheritance
+	{
+		class Base;
+	}
+}
+
+namespace io
+{
+	template<> std::string get_class_name<test::multiple_inheritance::Base>() 
+	{ 
+		return AS_TEXT(multiple_inheritance::Base); 
+	}
+
+} // namespace io

--- a/io/IOTraitFunctions.h
+++ b/io/IOTraitFunctions.h
@@ -33,4 +33,15 @@ namespace io
 		static void unserialize(T &value, XmlDocNodePtr const &node) { value = std::stof(node->get_value()); }
 	};
 
+	template<typename T>
+	extern std::string get_class_name();
+
+	template<typename T>
+	struct trait_functions<T, std::enable_if_t<std::is_class<T>::value>>
+	{
+		static auto constexpr name() { return get_class_name<T>(); }
+		static void serialize(T const &value, XmlDocNodePtr const &node) { value.serialize(node); }
+		static void unserialize(T const &value, XmlDocNodePtr const &node) { value.unserialize(node); }
+	};
+
 } // namespace io

--- a/io/IOTraitFunctions.h
+++ b/io/IOTraitFunctions.h
@@ -33,6 +33,14 @@ namespace io
 		static void unserialize(T &value, XmlDocNodePtr const &node) { value = std::stof(node->get_value()); }
 	};
 
+	template<>
+	struct trait_functions<std::string>
+	{
+		static auto constexpr name() { return "std::string"; }
+		static void serialize(std::string const &str, XmlDocNodePtr const &node) { node->set_value(str); }
+		static void unserialize(std::string &str, XmlDocNodePtr const &node) { str = std::move(node->get_value()); }
+	};
+
 	template<typename T>
 	extern std::string get_class_name();
 
@@ -41,7 +49,7 @@ namespace io
 	{
 		static auto constexpr name() { return get_class_name<T>(); }
 		static void serialize(T const &value, XmlDocNodePtr const &node) { value.serialize(node); }
-		static void unserialize(T const &value, XmlDocNodePtr const &node) { value.unserialize(node); }
+		static void unserialize(T &value, XmlDocNodePtr const &node) { value.unserialize(node); }
 	};
 
 } // namespace io

--- a/io/IOTypes.h
+++ b/io/IOTypes.h
@@ -45,6 +45,21 @@ namespace io
 		CreateFunc create_func;
 	};
 
+	template<typename T>
+	struct InheritancePointerInput
+	{
+		std::string name;
+		ptr_t<T> const &ptr;
+	};
+
+	template<typename T, typename CreateByIdentityFunc>
+	struct InheritancePointerOutput
+	{
+		std::string name;
+		ptr_t<T> &ptr;
+		CreateByIdentityFunc create_func_by_identity;
+	};
+
 	// TODO: убрать или перенести хелперные методы.
 
 	template<typename T>
@@ -70,6 +85,7 @@ namespace io
 	{
 		return io::ReferenceOutput<BaseObjId>{base_obj_id, ref_name};
 	}
+
 	template<typename T>
 	auto pointer_input(char const *ptr_name, ptr_t<T> const &ptr)
 	{
@@ -82,6 +98,18 @@ namespace io
 		return io::PointerOutput<T, CreateFunc>{ptr_name, ptr, create_func};
 	}
 
+	template<typename T>
+	auto inheritance_pointer_input(char const *ptr_name, ptr_t<T> const &ptr)
+	{
+		return io::InheritancePointerInput<T>{ptr_name, ptr};
+	}
+
+	template<typename T, typename CreateByIdentityFunc>
+	auto inheritance_pointer_output(char const *ptr_name, ptr_t<T> &ptr, CreateByIdentityFunc create_by_identity_func)
+	{
+		return io::InheritancePointerOutput<T, CreateByIdentityFunc>{ptr_name, ptr, create_by_identity_func};
+	}
+
 	#define IO_CONSTANT(c) io::constant(#c, c)
 	#define IO_VARIABLE(v) io::variable(#v, v)
 
@@ -90,5 +118,8 @@ namespace io
 
 	#define IO_POINTER_INPUT(ptr) io::pointer_input(#ptr, ptr)
 	#define IO_POINTER_OUTPUT(ptr, create_func) io::pointer_output(#ptr, ptr, create_func)
+
+	#define IO_INHERITANCE_POINTER_INPUT(ptr) io::inheritance_pointer_input(#ptr, ptr)
+	#define IO_INHERITANCE_POINTER_OUTPUT(ptr, create_func) io::inheritance_pointer_output(#ptr, ptr, create_func)
 
 } // namespace io

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -9,5 +9,7 @@ int main()
 
 	serialization_tests::arithmetic::struct_with_arithmetic_types();
 
+	serialization_tests::inheritance::multiple();
+
 	return 0;
 }

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -10,6 +10,7 @@ int main()
 	serialization_tests::arithmetic::struct_with_arithmetic_types();
 
 	serialization_tests::inheritance::multiple();
+	serialization_tests::inheritance::diamond();
 
 	return 0;
 }

--- a/main/pch.h
+++ b/main/pch.h
@@ -6,6 +6,7 @@
 #include <map>
 
 #include <algorithm>
+#include <functional>
 #include <memory>
 
 #include <type_traits>

--- a/tests/IntsTests.cpp
+++ b/tests/IntsTests.cpp
@@ -1,6 +1,7 @@
 ﻿#include "main/pch.h"
 #include "tests/SerializationTests.h"
 #include "tests/classes/Ints.h"
+#include "utils/PointerTable.h"
 
 namespace
 {
@@ -63,6 +64,8 @@ namespace serialization_tests
 			saved.p4 = nullptr;
 
 			test_common_helpers::serialize(saved, filename);
+
+			PointerTable<int>::clear();
 
 			test::PointersToInts loaded{};
 			loaded.unserialize(xml::Doc::make_by_file(filename));

--- a/tests/MultipleInheritanceTest.cpp
+++ b/tests/MultipleInheritanceTest.cpp
@@ -1,6 +1,7 @@
 ﻿#include "main/pch.h"
 #include "tests/SerializationTests.h"
 #include "tests/classes/MultipleInheritance.h"
+#include "utils/PointerTable.h"
 
 namespace serialization_tests
 {
@@ -10,13 +11,47 @@ namespace serialization_tests
 		{
 			using namespace test::multiple_inheritance;
 
+			Base const base_init('b');
+			Derived1 const derived1_init('b', 'd', 1);
+
+			ptr_t<double> const double_ptr_init = factory::create<double>(3.1415926);
+			Derived2 const derived2_init('b', "holds pointer", double_ptr_init);
+
+			DerivedFromDerived2 const derived_from_derived2_init(derived2_init, 321);
+
 			std::string const filename("results/multiple_inheritance_serialization.xml");
 
-			Pointers const saved{};
+			Pointers saved{};
+
+			saved.base_ptr = factory::create<Base>(base_init);
+			saved.base_ptr1 = factory::create<Derived1>(derived1_init);
+			saved.base_ptr2 = factory::create<Derived2>(derived2_init);
+			saved.base_ptr3 = factory::create<DerivedFromDerived2>(derived_from_derived2_init);
+
+			saved.base_ptr4 = saved.base_ptr1;
+			saved.base_ptr5 = nullptr;
+
 			test_common_helpers::serialize(saved, filename);
+
+			PointerTable<Base>::clear();
 
 			Pointers loaded{};
 			loaded.unserialize(xml::Doc::make_by_file(filename));
+
+			auto base = std::dynamic_pointer_cast<Base>(loaded.base_ptr);
+			auto derived1 = std::dynamic_pointer_cast<Derived1>(loaded.base_ptr1);
+			auto derived2 = std::dynamic_pointer_cast<Derived2>(loaded.base_ptr2);
+			auto derived_from_derived2 = std::dynamic_pointer_cast<DerivedFromDerived2>(loaded.base_ptr3);
+
+			assert(base && *base == base_init);
+			assert(derived1 && *derived1 == derived1_init);
+			assert(derived2 && *derived2 == derived2_init);
+			assert(derived_from_derived2 && *derived_from_derived2 == derived_from_derived2_init);
+
+			assert(derived2->get_double_ptr() == derived_from_derived2->get_double_ptr());
+
+			assert(loaded.base_ptr4 == loaded.base_ptr1);
+			assert(loaded.base_ptr5 == nullptr);
 		}
 
 	} // namespace inheritance

--- a/tests/MultipleInheritanceTest.cpp
+++ b/tests/MultipleInheritanceTest.cpp
@@ -1,0 +1,24 @@
+﻿#include "main/pch.h"
+#include "tests/SerializationTests.h"
+#include "tests/classes/MultipleInheritance.h"
+
+namespace serialization_tests
+{
+	namespace inheritance
+	{
+		void multiple()
+		{
+			using namespace test::multiple_inheritance;
+
+			std::string const filename("results/multiple_inheritance_serialization.xml");
+
+			Pointers const saved{};
+			test_common_helpers::serialize(saved, filename);
+
+			Pointers loaded{};
+			loaded.unserialize(xml::Doc::make_by_file(filename));
+		}
+
+	} // namespace inheritance
+
+} // namespace test

--- a/tests/SerializationTests.h
+++ b/tests/SerializationTests.h
@@ -20,6 +20,8 @@ namespace serialization_tests
 	namespace inheritance
 	{
 		void multiple();
+		void diamond();
+		void double_diamond();
 
 	} // namespace inheritance
 

--- a/tests/SerializationTests.h
+++ b/tests/SerializationTests.h
@@ -17,6 +17,12 @@ namespace serialization_tests
 
 	} // namespace arithmetic
 
+	namespace inheritance
+	{
+		void multiple();
+
+	} // namespace inheritance
+
 } // namespace serialization_tests
 
 namespace test_common_helpers

--- a/tests/VirtualInheritanceTest.cpp
+++ b/tests/VirtualInheritanceTest.cpp
@@ -1,0 +1,51 @@
+﻿#include "main/pch.h"
+#include "tests/SerializationTests.h"
+#include "tests/classes/VirtualInheritance.h"
+#include "utils/PointerTable.h"
+
+namespace serialization_tests
+{
+	namespace inheritance
+	{
+		void diamond()
+		{
+			using namespace test::virtual_inheritance;
+
+			std::string const filename("results/virtual_inheritance_serialization.xml");
+
+			D1 const d1_init(0, 1);
+			Join const join_init(0, 1, 2, 3);
+			JoinD2 const join_d2_init(join_init, 5);
+			JoinJoin const jjoin_init(join_init, 4, 5, 6);
+
+			Pointers saved;
+
+			saved.b_ptr1 = factory::create<D1>(d1_init);
+			saved.b_ptr2 = factory::create<Join>(join_init);
+			saved.b_ptr3 = factory::create<JoinD2>(join_d2_init);
+			saved.b_ptr4 = factory::create<JoinJoin>(jjoin_init);
+
+			test_common_helpers::serialize(saved, filename);
+
+			Pointers loaded;
+			loaded.unserialize(xml::Doc::make_by_file(filename));
+
+			auto d1 = std::dynamic_pointer_cast<D1>(loaded.b_ptr1);
+			auto join = std::dynamic_pointer_cast<Join>(loaded.b_ptr2);
+			auto join_d2 = std::dynamic_pointer_cast<JoinD2>(loaded.b_ptr3);
+			auto jjoin = std::dynamic_pointer_cast<JoinJoin>(loaded.b_ptr4);
+
+			assert(d1 && *d1 == d1_init);
+			assert(join && *join == join_init);
+			assert(join_d2 && *join_d2 == join_d2_init);
+			assert(jjoin && *jjoin == jjoin_init);
+		}
+
+		void double_diamond()
+		{
+
+		}
+
+	} // namespace inheritance
+
+} // namespace test

--- a/tests/classes/MultipleInheritance.cpp
+++ b/tests/classes/MultipleInheritance.cpp
@@ -1,0 +1,37 @@
+﻿#include "main/pch.h"
+#include "tests/classes/MultipleInheritance.h"
+#include "io/XmlIOStream.h"
+
+namespace test
+{
+	namespace multiple_inheritance
+	{
+		void Base::serialize(XmlDocNodePtr const &node) const
+		{
+		}
+
+		bool Base::unserialize(XmlDocNodePtr const &node)
+		{
+			return true;
+		}
+
+		void Derived1::serialize(XmlDocNodePtr const &node) const
+		{
+		}
+
+		bool Derived1::unserialize(XmlDocNodePtr const &node)
+		{
+			return true;
+		}
+
+		void Pointers::serialize(XmlDocNodePtr const &node) const
+		{
+		}
+
+		void Pointers::unserialize(XmlDocNodePtr const &node)
+		{
+		}
+
+	} // namespace multiple_inheritance
+
+} // namespace test

--- a/tests/classes/MultipleInheritance.cpp
+++ b/tests/classes/MultipleInheritance.cpp
@@ -1,36 +1,187 @@
 ﻿#include "main/pch.h"
 #include "tests/classes/MultipleInheritance.h"
+#include "utils/InheritanceGuards.h"
 #include "io/XmlIOStream.h"
 
 namespace test
 {
 	namespace multiple_inheritance
 	{
+		#define MULTIPLE_INHERITANCE_IDENTITY(ClassName) \
+				{AS_TEXT(ClassName), []()->ptr_t<test::multiple_inheritance::Base>{ return factory::create<ClassName>(); }}
+
+		using BaseCreateFunc = ptr_t<test::multiple_inheritance::Base>(*)();
+
+		BaseCreateFunc unserialize_identity(std::string const &identity)
+		{
+			static std::map<std::string, BaseCreateFunc> const identities
+			{
+				MULTIPLE_INHERITANCE_IDENTITY(Base),
+				MULTIPLE_INHERITANCE_IDENTITY(Derived1),
+				MULTIPLE_INHERITANCE_IDENTITY(Derived2),
+				MULTIPLE_INHERITANCE_IDENTITY(DerivedFromDerived2),
+			};
+
+			auto it = identities.find(identity);
+
+			assert((it != identities.cend()) && L"Неизвестный идентификатор класса");
+
+			return (it != identities.cend()) ? it->second : nullptr;
+		}
+
+		#undef MULTIPLE_INHERITANCE_IDENTITY
+
+		Base::Base(char b)
+			: ch(b)
+		{
+		}
+
+		bool Base::operator==(Base const &rhs) const
+		{
+			if (&rhs == this)
+			{
+				return true;
+			}
+
+			return ch == rhs.ch;
+		}
+
 		void Base::serialize(XmlDocNodePtr const &node) const
 		{
+			auto const guard = inheritance::IdentityGuard::get(AS_TEXT(Base), node);
+			io::XmlIOStream{node} << IO_CONSTANT(ch);
 		}
 
 		bool Base::unserialize(XmlDocNodePtr const &node)
 		{
+			io::XmlIOStream{node} >> IO_VARIABLE(ch);
 			return true;
+		}
+
+		Derived1::Derived1(char b, char d, int num)
+			: Base(b)
+			, ch(d)
+			, i(num)
+		{
+		}
+
+		bool Derived1::operator==(Derived1 const &rhs) const
+		{
+			if (&rhs == this)
+			{
+				return true;
+			}
+
+			return Base::operator==(rhs) && (ch == rhs.ch) && (i == rhs.i);
 		}
 
 		void Derived1::serialize(XmlDocNodePtr const &node) const
 		{
+			auto const guard = inheritance::IdentityGuard::get(AS_TEXT(Derived1), node);
+			Base::serialize(node);
+			io::XmlIOStream{node} 
+				/*
+					Имя переменной ch совпадает с именем переменной в базовом классе - 
+					чтобы избежать неоднозначностей при чтении,
+					можно использовать явное указание области видимости переменной.
+				*/
+				<< IO_CONSTANT(Derived1::ch) 
+				<< IO_CONSTANT(i);
 		}
 
 		bool Derived1::unserialize(XmlDocNodePtr const &node)
 		{
+			Base::unserialize(node);
+			io::XmlIOStream{node} >> IO_VARIABLE(Derived1::ch) >> IO_VARIABLE(i);
+			return true;
+		}
+
+		Derived2::Derived2(char b, std::string const &s, ptr_t<double> const &p)
+			: Base(b)
+			, str(s)
+			, ptr(p)
+		{
+		}
+
+		bool Derived2::operator==(Derived2 const &rhs) const
+		{
+			if (&rhs == this)
+			{
+				return true;
+			}
+
+			if ((!ptr && rhs.ptr) || (ptr && !rhs.ptr))
+			{
+				return false;
+			}
+
+			return Base::operator==(rhs) && (str == rhs.str) && 
+					((!ptr && !rhs.ptr) || (is_equal(*ptr,*rhs.ptr)));
+		}
+
+		void Derived2::serialize(XmlDocNodePtr const &node) const
+		{
+			auto const guard = inheritance::IdentityGuard::get(AS_TEXT(Derived2), node);
+			Base::serialize(node);
+			io::XmlIOStream{node} << IO_CONSTANT(str) << IO_POINTER_INPUT(ptr);
+		}
+
+		bool Derived2::unserialize(XmlDocNodePtr const &node)
+		{
+			Base::unserialize(node);
+			io::XmlIOStream{node} >> IO_VARIABLE(str) >> IO_POINTER_OUTPUT(ptr, factory::create<double>);
+			return true;
+		}
+
+		DerivedFromDerived2::DerivedFromDerived2(Derived2 const &d2, unsigned short u)
+			: Derived2(d2)
+			, ush(u)
+		{
+		}
+
+		bool DerivedFromDerived2::operator==(DerivedFromDerived2 const &rhs) const
+		{
+			if (&rhs == this)
+			{
+				return true;
+			}
+
+			return Derived2::operator==(rhs) && (ush == rhs.ush);
+		}
+
+
+		void DerivedFromDerived2::serialize(XmlDocNodePtr const &node) const
+		{
+			auto const guard = inheritance::IdentityGuard::get(AS_TEXT(DerivedFromDerived2), node);
+			Derived2::serialize(node);
+			io::XmlIOStream{node} << IO_CONSTANT(ush);
+		}
+
+		bool DerivedFromDerived2::unserialize(XmlDocNodePtr const &node)
+		{
+			Derived2::unserialize(node);
+			io::XmlIOStream{node} >> IO_VARIABLE(ush);
 			return true;
 		}
 
 		void Pointers::serialize(XmlDocNodePtr const &node) const
 		{
+			io::XmlIOStream{node} << IO_INHERITANCE_POINTER_INPUT(base_ptr)
+				<< IO_INHERITANCE_POINTER_INPUT(base_ptr1) << IO_INHERITANCE_POINTER_INPUT(base_ptr2)
+				<< IO_INHERITANCE_POINTER_INPUT(base_ptr3) << IO_INHERITANCE_POINTER_INPUT(base_ptr4)
+				<< IO_INHERITANCE_POINTER_INPUT(base_ptr5);
 		}
 
 		void Pointers::unserialize(XmlDocNodePtr const &node)
 		{
+			io::XmlIOStream{node} >> IO_INHERITANCE_POINTER_OUTPUT(base_ptr, unserialize_identity)
+				>> IO_INHERITANCE_POINTER_OUTPUT(base_ptr1, unserialize_identity)
+				>> IO_INHERITANCE_POINTER_OUTPUT(base_ptr2, unserialize_identity)
+				>> IO_INHERITANCE_POINTER_OUTPUT(base_ptr3, unserialize_identity)
+				>> IO_INHERITANCE_POINTER_OUTPUT(base_ptr4, unserialize_identity)
+				>> IO_INHERITANCE_POINTER_OUTPUT(base_ptr5, unserialize_identity);
 		}
+
 
 	} // namespace multiple_inheritance
 

--- a/tests/classes/MultipleInheritance.h
+++ b/tests/classes/MultipleInheritance.h
@@ -8,25 +8,65 @@ namespace test
 		class Base
 		{
 		public:
+			Base(char b = {});
 			virtual ~Base() = default;
+
+			bool operator==(Base const &rhs) const;
 
 			virtual void serialize(XmlDocNodePtr const &node) const;
 			virtual bool unserialize(XmlDocNodePtr const &node);
 
 		private:
-			char ch{'b'};
+			char ch{};
 		};
 
 		class Derived1 : public Base
 		{
 		public:
+			Derived1(char b = {}, char d = {}, int num = {});
 			~Derived1() override = default;
 
-			void serialize(XmlDocNodePtr const &node) const;
-			bool unserialize(XmlDocNodePtr const &node);
+			bool operator==(Derived1 const &rhs) const;
+
+			void serialize(XmlDocNodePtr const &node) const override;
+			bool unserialize(XmlDocNodePtr const &node) override;
 
 		private:
-			char ch{'d'};
+			char ch{};
+			int i{};
+		};
+
+		class Derived2 : public Base
+		{
+		public:
+			Derived2(char b = {}, std::string const &s = {}, ptr_t<double> const &p = {});
+			~Derived2() override = default;
+
+			bool operator==(Derived2 const &rhs) const;
+
+			void serialize(XmlDocNodePtr const &node) const override;
+			bool unserialize(XmlDocNodePtr const &node) override;
+
+			ptr_t<double> get_double_ptr() const { return ptr; }
+
+		private:
+			std::string str;
+			ptr_t<double> ptr;
+		};
+
+		class DerivedFromDerived2 : public Derived2
+		{
+		public:
+			DerivedFromDerived2(Derived2 const &d2 = {}, unsigned short u = {});
+			~DerivedFromDerived2() override = default;
+
+			bool operator==(DerivedFromDerived2 const &rhs) const;
+
+			void serialize(XmlDocNodePtr const &node) const override;
+			bool unserialize(XmlDocNodePtr const &node) override;
+
+		private:
+			unsigned short ush{};
 		};
 
 		using BasePtr = ptr_t<Base>;
@@ -35,7 +75,8 @@ namespace test
 
 		struct Pointers
 		{
-			BasePtr base_ptr1{}, base_ptr2{};
+			BasePtr base_ptr{}, base_ptr1{}, base_ptr2{}, base_ptr3{}, 
+					base_ptr4{}, base_ptr5{};
 
 			void serialize(XmlDocNodePtr const &node) const;
 			void unserialize(XmlDocNodePtr const &node);

--- a/tests/classes/MultipleInheritance.h
+++ b/tests/classes/MultipleInheritance.h
@@ -1,0 +1,46 @@
+﻿#pragma once
+#include "interfaces/XmlDocNode.h"
+
+namespace test
+{
+	namespace multiple_inheritance
+	{
+		class Base
+		{
+		public:
+			virtual ~Base() = default;
+
+			virtual void serialize(XmlDocNodePtr const &node) const;
+			virtual bool unserialize(XmlDocNodePtr const &node);
+
+		private:
+			char ch{'b'};
+		};
+
+		class Derived1 : public Base
+		{
+		public:
+			~Derived1() override = default;
+
+			void serialize(XmlDocNodePtr const &node) const;
+			bool unserialize(XmlDocNodePtr const &node);
+
+		private:
+			char ch{'d'};
+		};
+
+		using BasePtr = ptr_t<Base>;
+
+		// TODO (опционально): добавить пример с массивом указателей
+
+		struct Pointers
+		{
+			BasePtr base_ptr1{}, base_ptr2{};
+
+			void serialize(XmlDocNodePtr const &node) const;
+			void unserialize(XmlDocNodePtr const &node);
+		};
+
+	} // namespace multiple_inheritance
+
+} // namespace test

--- a/tests/classes/VirtualInheritance.cpp
+++ b/tests/classes/VirtualInheritance.cpp
@@ -1,0 +1,241 @@
+﻿#include "main/pch.h"
+#include "tests/classes/VirtualInheritance.h"
+#include "utils/InheritanceGuards.h"
+#include "io/XmlIOStream.h"
+
+namespace test
+{
+	namespace virtual_inheritance
+	{
+		#define VIRTUAL_INHERITANCE_IDENTITY(ClassName) \
+				{AS_TEXT(ClassName), []()->ptr_t<test::virtual_inheritance::B>{ return factory::create<ClassName>(); }}
+
+		using BaseCreateFunc = ptr_t<test::virtual_inheritance::B>(*)();
+
+		BaseCreateFunc unserialize_identity(std::string const &identity)
+		{
+			static std::map<std::string, BaseCreateFunc> const identities
+			{
+				VIRTUAL_INHERITANCE_IDENTITY(B),
+				VIRTUAL_INHERITANCE_IDENTITY(D1),
+				VIRTUAL_INHERITANCE_IDENTITY(D2),
+				VIRTUAL_INHERITANCE_IDENTITY(Join),
+				VIRTUAL_INHERITANCE_IDENTITY(JoinD1),
+				VIRTUAL_INHERITANCE_IDENTITY(JoinD2),
+				VIRTUAL_INHERITANCE_IDENTITY(JoinJoin),
+			};
+
+			auto it = identities.find(identity);
+
+			assert((it != identities.cend()) && L"Неизвестный идентификатор класса");
+
+			return (it != identities.cend()) ? it->second : nullptr;
+		}
+
+		#undef VIRTUAL_INHERITANCE_IDENTITY
+
+		bool B::operator==(B const &rhs) const
+		{
+			if (&rhs == this)
+			{
+				return true;
+			}
+
+			return b == rhs.b;
+		}
+
+		void B::serialize(XmlDocNodePtr const &node) const
+		{
+			auto const guard = inheritance::IdentityGuard::get(AS_TEXT(B), node);
+			io::XmlIOStream{node} << IO_CONSTANT(b);
+		}
+
+		bool B::unserialize(XmlDocNodePtr const &node)
+		{
+			io::XmlIOStream{node} >> IO_VARIABLE(b);
+			return true;
+		}
+
+		inheritance::VirtualGuard<B> B::get_virtual_guard(XmlDocNodePtr const &node) const
+		{
+			return inheritance::VirtualGuard<B>([this, &node]{ return this->B::serialize(node); });
+		}
+
+		bool D1::operator==(D1 const &rhs) const
+		{
+			if (&rhs == this)
+			{
+				return true;
+			}
+
+			return B::operator==(rhs) && (d1 == rhs.d1);
+		}
+
+		void D1::serialize(XmlDocNodePtr const &node) const
+		{
+			auto const identity_guard = inheritance::IdentityGuard::get(AS_TEXT(D1), node);
+			auto const virtual_guard = B::get_virtual_guard(node);	
+			io::XmlIOStream{node} << IO_CONSTANT(d1);
+		}
+
+		bool D1::unserialize(XmlDocNodePtr const &node)
+		{
+			B::unserialize(node);
+			io::XmlIOStream{node} >> IO_VARIABLE(d1);
+			return true;
+		}
+
+		bool D2::operator==(D2 const &rhs) const
+		{
+			if (&rhs == this)
+			{
+				return true;
+			}
+
+			return B::operator==(rhs) && (d2 == rhs.d2);
+		}
+
+		void D2::serialize(XmlDocNodePtr const &node) const
+		{
+			auto const identity_guard = inheritance::IdentityGuard::get(AS_TEXT(D2), node);
+			auto const virtual_guard = B::get_virtual_guard(node);
+			io::XmlIOStream{node} << IO_CONSTANT(d2);
+		}
+
+		bool D2::unserialize(XmlDocNodePtr const &node)
+		{
+			B::unserialize(node);
+			io::XmlIOStream{node} >> IO_VARIABLE(d2);
+			return true;
+		}
+
+		bool Join::operator==(Join const &rhs) const
+		{
+			if (&rhs == this)
+			{
+				return true;
+			}
+
+			return D1::operator==(rhs) && D2::operator==(rhs) && (join == rhs.join);
+		}
+
+		void Join::serialize(XmlDocNodePtr const &node) const
+		{
+			auto const identity_guard = inheritance::IdentityGuard::get(AS_TEXT(Join), node);
+			auto const virtual_guard = B::get_virtual_guard(node);
+
+			D1::serialize(node);
+			D2::serialize(node);
+
+			io::XmlIOStream{node} << IO_CONSTANT(join);
+		}
+
+		bool Join::unserialize(XmlDocNodePtr const &node)
+		{
+			D1::unserialize(node);
+			D2::unserialize(node);
+			io::XmlIOStream{node} >> IO_VARIABLE(join);
+			return true;
+		}
+
+		inheritance::VirtualGuard<Join> Join::get_virtual_guard(XmlDocNodePtr const &node) const
+		{
+			return inheritance::VirtualGuard<Join>([this, &node]{ return this->Join::serialize(node); });
+		}
+
+		bool JoinD1::operator==(JoinD1 const &rhs) const
+		{
+			if (&rhs == this)
+			{
+				return true;
+			}
+
+			return Join::operator==(rhs) && (jd1 == rhs.jd1);
+		}
+
+		void JoinD1::serialize(XmlDocNodePtr const &node) const
+		{
+			auto const identity_guard = inheritance::IdentityGuard::get(AS_TEXT(JoinD1), node);
+			auto const virtual_guard = Join::get_virtual_guard(node);
+			io::XmlIOStream{node} << IO_CONSTANT(jd1);
+		}
+
+		bool JoinD1::unserialize(XmlDocNodePtr const &node)
+		{
+			B::unserialize(node);
+			io::XmlIOStream{node} >> IO_VARIABLE(jd1);
+			return true;
+		}
+
+		bool JoinD2::operator==(JoinD2 const &rhs) const
+		{
+			if (&rhs == this)
+			{
+				return true;
+			}
+
+			return Join::operator==(rhs) && (jd2 == rhs.jd2);
+		}
+
+		void JoinD2::serialize(XmlDocNodePtr const &node) const
+		{
+			auto const identity_guard = inheritance::IdentityGuard::get(AS_TEXT(JoinD2), node);
+			auto const virtual_guard = Join::get_virtual_guard(node);
+			io::XmlIOStream{node} << IO_CONSTANT(jd2);
+		}
+
+		bool JoinD2::unserialize(XmlDocNodePtr const &node)
+		{
+			B::unserialize(node);
+			io::XmlIOStream{node} >> IO_VARIABLE(jd2);
+			return true;
+		}
+
+		bool JoinJoin::operator==(JoinJoin const &rhs) const
+		{
+			if (&rhs == this)
+			{
+				return true;
+			}
+
+			return JoinD1::operator==(rhs) && JoinD2::operator==(rhs) && (jjoin == rhs.jjoin);
+		}
+
+		void JoinJoin::serialize(XmlDocNodePtr const &node) const
+		{
+			auto const identity_guard = inheritance::IdentityGuard::get(AS_TEXT(JoinJoin), node);
+			auto const virtual_guard = Join::get_virtual_guard(node);
+
+			JoinD1::serialize(node);
+			JoinD2::serialize(node);
+
+			io::XmlIOStream{node} << IO_CONSTANT(jjoin);
+		}
+
+		bool JoinJoin::unserialize(XmlDocNodePtr const &node)
+		{
+			JoinD1::unserialize(node);
+			JoinD2::unserialize(node);
+			io::XmlIOStream{node} >> IO_VARIABLE(jjoin);
+			return true;
+		}
+
+		void Pointers::serialize(XmlDocNodePtr const &node) const
+		{
+			io::XmlIOStream{node} << IO_INHERITANCE_POINTER_INPUT(b_ptr1)
+				<< IO_INHERITANCE_POINTER_INPUT(b_ptr2)
+				<< IO_INHERITANCE_POINTER_INPUT(b_ptr3)
+				<< IO_INHERITANCE_POINTER_INPUT(b_ptr4);
+		}
+
+		void Pointers::unserialize(XmlDocNodePtr const &node)
+		{
+			io::XmlIOStream{node} >> IO_INHERITANCE_POINTER_OUTPUT(b_ptr1, unserialize_identity)
+				>> IO_INHERITANCE_POINTER_OUTPUT(b_ptr2, unserialize_identity)
+				>> IO_INHERITANCE_POINTER_OUTPUT(b_ptr3, unserialize_identity)
+				>> IO_INHERITANCE_POINTER_OUTPUT(b_ptr4, unserialize_identity);
+		}
+
+	} // namespace virtual_inheritance
+
+} // namespace test

--- a/tests/classes/VirtualInheritance.h
+++ b/tests/classes/VirtualInheritance.h
@@ -1,0 +1,127 @@
+﻿#pragma once
+#include "interfaces/XmlDocNode.h"
+
+namespace inheritance
+{
+	template<typename VirtualInheritanceBase>
+	class VirtualGuard;
+}
+
+namespace test
+{
+	namespace virtual_inheritance
+	{
+		struct B
+		{
+			B(int i = {}) : b(i) {}
+			virtual ~B() = default;
+
+			bool operator==(B const &rhs) const;
+
+			virtual void serialize(XmlDocNodePtr const &node) const;
+			virtual bool unserialize(XmlDocNodePtr const &node);
+
+			int b{};
+
+		protected:
+			inheritance::VirtualGuard<B> get_virtual_guard(XmlDocNodePtr const &node) const;
+		};
+
+		struct D1 : public virtual B
+		{
+			D1(int i = {}, int d = {}) : B(i), d1(d) {}
+			~D1() override = default;
+
+			bool operator==(D1 const &rhs) const;
+
+			void serialize(XmlDocNodePtr const &node) const override;
+			bool unserialize(XmlDocNodePtr const &node) override;
+
+			int d1{};
+		};
+
+		struct D2 : public virtual B
+		{
+			D2(int i = {}, int d = {}) : B(i), d2(d) {}
+			~D2() override = default;
+
+			bool operator==(D2 const &rhs) const;
+
+			void serialize(XmlDocNodePtr const &node) const override;
+			bool unserialize(XmlDocNodePtr const &node) override;
+
+			int d2{};
+		};
+
+		struct Join : public D1, public D2
+		{
+			Join(int i = {}, int d1 = {}, int d2 = {}, int j = {}) 
+				: B(i), D1(i, d1), D2(i, d2), join(j) 
+			{
+			}
+			~Join() override = default;
+
+			bool operator==(Join const &rhs) const;
+
+			void serialize(XmlDocNodePtr const &node) const override;
+			bool unserialize(XmlDocNodePtr const &node) override;
+
+			int join{};
+
+		protected:
+			inheritance::VirtualGuard<Join> get_virtual_guard(XmlDocNodePtr const &node) const;
+		};
+
+		struct JoinD1 : public virtual Join
+		{
+			JoinD1(Join const &j = {}, int d = {}) : Join(j), jd1(d) {}
+			~JoinD1() override = default;
+
+			bool operator==(JoinD1 const &rhs) const;
+
+			void serialize(XmlDocNodePtr const &node) const override;
+			bool unserialize(XmlDocNodePtr const &node) override;
+
+			int jd1{};
+		};
+
+		struct JoinD2 : public virtual Join
+		{
+			JoinD2(Join const &j = {}, int d = {}) : Join(j), jd2(d) {}
+			~JoinD2() override = default;
+
+			bool operator==(JoinD2 const &rhs) const;
+
+			void serialize(XmlDocNodePtr const &node) const override;
+			bool unserialize(XmlDocNodePtr const &node) override;
+
+			int jd2{};
+		};
+
+		struct JoinJoin : public JoinD1, public JoinD2
+		{
+			JoinJoin(Join const &j = {}, int d1 = {}, int d2 = {}, int jj = {})
+				: Join(j), JoinD1(j, d1), JoinD2(j, d2), jjoin(jj)
+			{
+			}
+			~JoinJoin() override = default;
+
+			bool operator==(JoinJoin const &rhs) const;
+
+			void serialize(XmlDocNodePtr const &node) const override;
+			bool unserialize(XmlDocNodePtr const &node) override;
+
+			int jjoin{};
+		};
+
+		struct Pointers
+		{
+			ptr_t<B> b_ptr1{}, b_ptr2{}, b_ptr3{}, b_ptr4{};
+
+			void serialize(XmlDocNodePtr const &node) const;
+			void unserialize(XmlDocNodePtr const &node);
+		};
+
+	} // namespace virtual_inheritance
+
+} // namespace test

--- a/utils/InheritanceGuards.h
+++ b/utils/InheritanceGuards.h
@@ -1,0 +1,50 @@
+﻿#pragma once
+#include "interfaces/XmlDocNode.h"
+#include "xml/XmlAttributes.h"
+
+namespace inheritance
+{
+	struct IdentityTag {};
+	struct VirtualInheritanceTag {}; // NOTE: будет использовано для виртуального наследования.
+
+	template<typename Tag, std::enable_if_t<std::is_same<Tag, IdentityTag>::value ||
+											std::is_same<Tag, VirtualInheritanceTag>::value, int> = 0>
+		class NestedObjectsCounter
+	{
+	public:
+		virtual ~NestedObjectsCounter() { --objects_count; }
+
+	protected:
+		NestedObjectsCounter() { ++objects_count; }
+
+		int get_objects_count() const { return objects_count; }
+
+	private:
+		static int objects_count;
+	};
+
+	int NestedObjectsCounter<IdentityTag>::objects_count = 0;
+	int NestedObjectsCounter<VirtualInheritanceTag>::objects_count = 0;
+
+	/*
+		Выполняет сериализацию признака класса для первого объекта из цепочки вложенных объектов.
+	*/
+	class IdentityGuard : public NestedObjectsCounter<IdentityTag>
+	{
+	public:
+		static IdentityGuard get(std::string const &identity, XmlDocNodePtr const &node) 
+		{ 
+			return IdentityGuard(identity, node); 
+		}
+
+	private:
+		IdentityGuard(std::string const &identity, XmlDocNodePtr const &node)
+		{
+			if (get_objects_count() == 1)
+			{
+				node->add_attributes({{xml::attributes::ptr_identity, identity}});
+			}
+		}
+	};
+
+} // namespace inheritance

--- a/utils/PointerTable.h
+++ b/utils/PointerTable.h
@@ -12,6 +12,8 @@ public:
 	template<typename CreateFunc>
 	static ptr_t<T> get_pointer_by_id(PointerId const &id, CreateFunc create_func);
 
+	static void clear() { get_table().m_pointers.clear(); }
+
 private:
 	static PointerTable& get_table();
 

--- a/xml/XmlAttributes.h
+++ b/xml/XmlAttributes.h
@@ -8,6 +8,8 @@ namespace xml
 
 		auto constexpr ptr_id = "ptr_id";
 
+		auto constexpr ptr_identity = "ptr_identity";
+
 	} // namespace attributes
 
 } // namespace xml


### PR DESCRIPTION
**Сериализация классов-объектов множественного и виртуального наследования**

Основные инструменты добавлены в _utils/InheritanceUtils.h_ . Сериализация выполняется аналогично сериализации обычных указателей, с дополнением некоторых моментов:
- для _множественного наследования_ каждый класс-представитель иерархии пишет в поток свой уникальный идентификатов (_identity_), по которому при чтении можно будет создать объект требуемого типа. _IdentityGuard_ "следит" за тем, чтобы в поток попадал только идентификатор типа, сериализация которого выполняется.
- для _виртуального наследования_ _VirtualGuard_ "следит" за тем, чтобы в каждом "ромбе" базовый класс записывался только один раз (в остальном сериализация выполняется так же, как для множественного наследования).